### PR TITLE
ブランチデプロイ monitoringサーバへのリクエストがタイムアウト(対応)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ mirage-ecs can run and stop ECS tasks and proxy HTTP requests to the tasks with 
 
 ### Deployment(ECS)
 
-1. Set environment variables
+1. Set aws credential
+```
+export AWS_ACCESS_KEY_ID="xxxxxxxxxxxxxxxxx"
+export AWS_SECRET_ACCESS_KEY="xxxxxxxxxxxxxxxxx"
+export AWS_SESSION_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+2. Set environment variables
 ```
 AWS_ACCOUNT_ID=xxxxxxxxx
 IMAGE_REPOSITORY_NAME=yomel/devmirage/mirage-ecs
@@ -16,28 +23,28 @@ IMAGE_TAG=$(git log -n 1 --format=%H)
 REPOSITORY_URI=${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com/${IMAGE_REPOSITORY_NAME}
 ```
 
-2. Log in to ECR
+3. Log in to ECR
 ```
 aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com
 ```
 
-3. Docker image build
+4. Docker image build
 ```
 docker build -f ./docker/Dockerfile -t $REPOSITORY_URI:latest .
 ```
 
-4. Tag image
+5. Tag image
 ```
 docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
 ```
 
-4. Docker push
+6. Docker push
 ```
 docker push $REPOSITORY_URI:latest
 docker push $REPOSITORY_URI:$IMAGE_TAG
 ```
 
-5. Deploy ECS
+7. Deploy ECS
 
 Click 「Amazon Elastic Container Service > クラスター > yomel-devmirage-cluster 」
 

--- a/README.md
+++ b/README.md
@@ -8,24 +8,33 @@ mirage-ecs can run and stop ECS tasks and proxy HTTP requests to the tasks with 
 
 ### Deployment(ECS)
 
-1. Log in to ECR
+1. Set environment variables
 ```
-aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin ${account_id}.dkr.ecr.ap-northeast-1.amazonaws.com
-```
-
-2. Docker image build
-```
-docker build -t yomel/devmirage/mirage-ecs . -f ./docker/Dockerfile
+AWS_ACCOUNT_ID=xxxxxxxxx
+IMAGE_REPOSITORY_NAME=yomel/devmirage/mirage-ecs
+IMAGE_TAG=$(git log -n 1 --format=%H)
+REPOSITORY_URI=${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com/${IMAGE_REPOSITORY_NAME}
 ```
 
-3. Tag image
+2. Log in to ECR
 ```
-docker tag yomel/devmirage/mirage-ecs:latest ${account_id}.dkr.ecr.ap-northeast-1.amazonaws.com/yomel/devmirage/mirage-ecs:latest
+aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com
+```
+
+3. Docker image build
+```
+docker build -f ./docker/Dockerfile -t $REPOSITORY_URI:latest .
+```
+
+4. Tag image
+```
+docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
 ```
 
 4. Docker push
 ```
-docker push ${account_id}.dkr.ecr.ap-northeast-1.amazonaws.com/yomel/devmirage/mirage-ecs:latest
+docker push $REPOSITORY_URI:latest
+docker push $REPOSITORY_URI:$IMAGE_TAG
 ```
 
 5. Deploy ECS

--- a/README.md
+++ b/README.md
@@ -6,6 +6,39 @@ mirage-ecs can run and stop ECS tasks and proxy HTTP requests to the tasks with 
 
 ## Usage
 
+### Deployment(ECS)
+
+1. Log in to ECR
+```
+aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin ${account_id}.dkr.ecr.ap-northeast-1.amazonaws.com
+```
+
+2. Docker image build
+```
+docker build -t yomel/devmirage/mirage-ecs . -f ./docker/Dockerfile
+```
+
+3. Tag image
+```
+docker tag yomel/devmirage/mirage-ecs:latest ${account_id}.dkr.ecr.ap-northeast-1.amazonaws.com/yomel/devmirage/mirage-ecs:latest
+```
+
+4. Docker push
+```
+docker push ${account_id}.dkr.ecr.ap-northeast-1.amazonaws.com/yomel/devmirage/mirage-ecs:latest
+```
+
+5. Deploy ECS
+
+Click 「Amazon Elastic Container Service > クラスター > yomel-devmirage-cluster 」
+
+Click 「サービスを更新」
+
+Place a checkmark 「新しいデプロイの強制」
+
+Click 「更新」
+
+
 ### Minimal Configuration
 
 Set a single environment variable.

--- a/reverseproxy.go
+++ b/reverseproxy.go
@@ -224,6 +224,7 @@ func (r *ReverseProxy) AddSubdomain(subdomain string, ipaddress string, targetPo
 			continue
 		}
 		handler := rproxy.NewSingleHostReverseProxy(destUrl)
+		handler.FlushInterval = time.Second
 		tp := &Transport{
 			Transport: newHTTPTransport(r.cfg.Network.ProxyTimeout),
 			Counter:   counter,


### PR DESCRIPTION
### 対応内容
- ブランチデプロイ monitoringサーバへのリクエストがタイムアウト(対応)
    - https://app.clickup.com/t/9007119373/SRE-544

- mirage ecsをServer Sent Eventに対応する形に変更



### テスト内容
syncサーバーにsseのリクエストを送る
```
curl https://sync-develop5.test.devmirage.yomel.co/events/subscribe?target=ey.....
```

### テスト結果
下記レスポンスが即自配信される
```
data: subscribe start

id: 139628772419000
event: keepalive
data: ok

id: 139628797435000
event: keepalive
data: ok

id: 139628822443000
event: keepalive
data: ok

id: 139628847450000
event: keepalive
data: ok
```